### PR TITLE
rename "flash" button to "connect"

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
           <label for="pause"><br></label>
           <button id="pause" class="button" type="button" onclick="pauseUpdate()"><ion-icon name="pause"></ion-icon></button>
           <button id="trash" class="button" type="button" onclick="deleteData()" ><ion-icon name="trash"></ion-icon></button> 
-          <button id="connect" class="button" type="button" onclick="serial.connect()"><ion-icon name="flash"></ion-icon></button>
+          <button id="connect" class="button" type="button" onclick="serial.connect()"><ion-icon name="connect"></ion-icon></button>
         </div>
       </div>
       <div class="row" id="statsdiv">


### PR DESCRIPTION
...coming straight from "flashing" to the firmware to the controller board, I thought there might actually be an option to "flash" new firmware to the board when I saw this button. Renaming the button would minimize confusion.